### PR TITLE
feat: Implement delete airdrop functionality

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/ascr/airdropsfun/AirdropDetailScreen.kt
+++ b/app/src/main/java/com/ascr/airdropsfun/AirdropDetailScreen.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -27,6 +30,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,14 +44,18 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil.compose.AsyncImage
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AirdropDetailScreen(
     state: AirdropDetailState,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onDeleteClicked: () -> Unit
 ) {
     val context = LocalContext.current
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -58,8 +69,22 @@ fun AirdropDetailScreen(
                     IconButton(onClick = onNavigateBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Navigate back" // This is fine for a non-user-facing string
+                            contentDescription = "Navigate back"
                         )
+                    }
+                },
+                actions = {
+                    if (state is AirdropDetailState.Success) {
+                        val currentUser = Firebase.auth.currentUser
+                        if (currentUser?.uid == state.airdrop.ownerId) {
+                            IconButton(onClick = { showDeleteDialog = true }) {
+                                Icon(
+                                    imageVector = Icons.Default.Delete,
+                                    contentDescription = "Delete Airdrop",
+                                    tint = Color.White
+                                )
+                            }
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -82,12 +107,10 @@ fun AirdropDetailScreen(
                 }
                 is AirdropDetailState.Success -> {
                     val airdrop = state.airdrop
-                    // Use LazyColumn to allow scrolling if there are many steps
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(16.dp)
                     ) {
-                        // Item 1: Header with details
                         item {
                             Text(airdrop.titulo, style = MaterialTheme.typography.headlineLarge)
                             Spacer(modifier = Modifier.height(8.dp))
@@ -103,22 +126,18 @@ fun AirdropDetailScreen(
                                     text = stringResource(id = R.string.step_by_step_guide),
                                     style = MaterialTheme.typography.titleLarge
                                 )
-                                // CORRECTED: Used HorizontalDivider instead of deprecated Divider
                                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
                             }
                         }
 
-                        // Item 2: The list of steps
                         items(airdrop.steps) { step ->
                             AirdropStepItem(step = step)
                         }
 
-                        // Item 3: The button at the end
                         item {
                             Spacer(modifier = Modifier.height(16.dp))
                             Button(
                                 onClick = {
-                                    // CORRECTED: Used modern KTX extension function
                                     val intent = Intent(Intent.ACTION_VIEW, airdrop.enlace.toUri())
                                     context.startActivity(intent)
                                 },
@@ -140,11 +159,32 @@ fun AirdropDetailScreen(
             }
         }
     }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Confirm Deletion") },
+            text = { Text("Are you sure you want to delete this airdrop? This action cannot be undone.") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onDeleteClicked()
+                        showDeleteDialog = false
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) {
+                    Text("Confirm")
+                }
+            },
+            dismissButton = {
+                Button(onClick = { showDeleteDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
 }
 
-/**
- * A Composable to display a single step with its image and description.
- */
 @Composable
 fun AirdropStepItem(step: AirdropStep) {
     Card(
@@ -154,7 +194,6 @@ fun AirdropStepItem(step: AirdropStep) {
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column {
-            // AsyncImage from Coil loads the image from the URL.
             AsyncImage(
                 model = step.imageUrl,
                 contentDescription = step.description,

--- a/app/src/main/java/com/ascr/airdropsfun/AppNavigation.kt
+++ b/app/src/main/java/com/ascr/airdropsfun/AppNavigation.kt
@@ -26,9 +26,6 @@ fun AppNavigation() {
         navController = navController,
         startDestination = startDestination
     ) {
-        // LoginScreen, RegisterScreen, AirdropListScreen, and AirdropDetailScreen
-        // composables remain unchanged from the previous step.
-        // ...
         composable(Routes.LoginScreen.route) {
             val authState by authViewModel.authState.collectAsState()
 
@@ -94,6 +91,7 @@ fun AppNavigation() {
             )
         }
 
+        // --- CORRECCIÓN APLICADA AQUÍ ---
         composable(Routes.AirdropDetailScreen.route) { backStackEntry ->
             val airdropId = backStackEntry.arguments?.getString("airdropId")
             LaunchedEffect(airdropId) {
@@ -102,22 +100,28 @@ fun AppNavigation() {
                 }
             }
             val state by airdropViewModel.airdropDetailState.collectAsState()
+
             AirdropDetailScreen(
                 state = state,
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                // Conecta el evento de clic con la acción del ViewModel.
+                onDeleteClicked = {
+                    if (airdropId != null) {
+                        airdropViewModel.deleteAirdrop(airdropId)
+                        // Vuelve a la pantalla anterior después de borrar.
+                        navController.popBackStack()
+                    }
+                }
             )
         }
 
-        // UPDATE: Connect the onSaveClick lambda to the ViewModel.
         composable(Routes.AddAirdropScreen.route) {
             AddAirdropScreen(
                 onNavigateBack = {
                     navController.popBackStack()
                 },
                 onSaveClick = { titulo, fecha, descripcion, enlace ->
-                    // 1. Call the ViewModel to save the data to Firestore.
                     airdropViewModel.saveAirdrop(titulo, fecha, descripcion, enlace)
-                    // 2. Navigate back to the list screen.
                     navController.popBackStack()
                 }
             )


### PR DESCRIPTION
This pull request implements the functionality to delete an airdrop from the detail screen.

- Adds a delete icon to the TopAppBar for the airdrop's owner.
- Shows a confirmation dialog to prevent accidental deletion.
- Calls the ViewModel to perform the deletion in Firestore.
- Navigates back to the list screen upon successful deletion.

Closes #1